### PR TITLE
chore: ensure build check for autopick function

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npm run build"
+  command = "node --check netlify/functions/autopick-vip-nuevo.cjs && npm run build"
   publish = "."
   functions = "netlify/functions"
 

--- a/netlify/functions/autopick-vip-nuevo.cjs
+++ b/netlify/functions/autopick-vip-nuevo.cjs
@@ -553,18 +553,8 @@ async function obtenerPickConFallback(prompt, resumenRef = null) {
   }
   return { pick, modeloUsado: MODEL };
 }
-
-  // 2) Si no está completo (pero no dijo no_pick), probar fallback UNA vez
-  if (!pickCompleto(pick)) {
-    console.log('♻️ Fallback de modelo →', MODEL_FALLBACK);
-    modeloUsado = MODEL_FALLBACK;
-    pick = await pedirPickConModelo(MODEL_FALLBACK, prompt, resumenRef);
-  }
-
-  return { pick, modeloUsado };
-}
-
 // =============== PROMPT ===============
+// BUILD_MARK: 2025-08-09T16:38:03Z
 function construirOpcionesApostables(mejoresMercados) {
   if (!Array.isArray(mejoresMercados)) return [];
   return mejoresMercados.map(m => {


### PR DESCRIPTION
## Summary
- remove stray fallback snippet from autopick function
- add build marker comment and enable Node syntax check before build

## Testing
- `node --check netlify/functions/autopick-vip-nuevo.cjs`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689778eddb2c832a9bb9aac8a183ce4f