### PR TITLE
fix(afapi): importar afApi en autopick-vip-nuevo

### DIFF
--- a/netlify/functions/autopick-vip-nuevo.cjs
+++ b/netlify/functions/autopick-vip-nuevo.cjs
@@ -17,7 +17,7 @@ try {
 const OpenAI = require('openai');
 const fs = require('fs');
 const path = require('path');
-const { resolveFixtureFromList } = require('./_lib/af-resolver.cjs');
+const { afApi, resolveFixtureFromList } = require('./_lib/af-resolver.cjs');
 // Corazonada (tu módulo ya existente)
 const { computeCorazonada } = require('./_lib/_corazonada.cjs');
 const { createLogger } = require('./_lib/_logger.cjs');


### PR DESCRIPTION
### Contexto
Errores 500 en autopick causados por `afApi` no definido durante la resolución de fixtures (AF). Esto cortaba la cadena y evitaba el envío de picks al canal.

### Cambio
- Importación mínima (1 línea) en `netlify/functions/autopick-vip-nuevo.cjs`:
  `const { afApi, resolveFixtureFromList } = require('./_lib/af-resolver.cjs');`

### Riesgo
- Bajo. CommonJS, sin cambio de lógica. Mantiene formato y flujo existentes.

### Validación
- Compila y `require` ok (pendiente smoke local con `diag-require`).
- Próximo paso: merge a `main`, despliegue, y smoke de función para confirmar que ya no hay 500 y que los picks se envían.

### Objetivo inmediato
Restaurar envíos al canal y habilitar la prueba real (canal → botón → bot `/start` → onboarding → 15 días VIP).